### PR TITLE
Add additional logging message about setting `draft-after`.

### DIFF
--- a/_extensions/scheduled-docs/run-scheduled-docs.ts
+++ b/_extensions/scheduled-docs/run-scheduled-docs.ts
@@ -13,7 +13,7 @@ const tempFilesDir = configParams['temp-files-dir'];
 // Run functions
 let scheduledDocs = await readScheduledDocs(ymlPath, scheduledDocsKey, configParams);
 propagateKeys(scheduledDocs);
-setDraftStatuses(scheduledDocs, itemsKey);
+setDraftStatuses(scheduledDocs, itemsKey, ymlPath);
 await writeDraftList(scheduledDocs, tempFilesDir);
 await writeSchedule(scheduledDocs, tempFilesDir);
 await writeListingContents(scheduledDocs, tempFilesDir);

--- a/_extensions/scheduled-docs/scheduled-docs.ts
+++ b/_extensions/scheduled-docs/scheduled-docs.ts
@@ -79,7 +79,7 @@ export function propagateKeys(obj: any, parentProps: Record<string, string> = {}
 // Set draft values for all items and collects them
 // into a doclist key in the config file
 
-export function setDraftStatuses(obj, itemsKey: string = "docs") {
+export function setDraftStatuses(obj, itemsKey: string = "docs", ymlPath: string) {
   
   console.log("> Setting draft status of docs ...")
   const draftAfterStr = obj["draft-after"];
@@ -146,6 +146,9 @@ export function setDraftStatuses(obj, itemsKey: string = "docs") {
   
   console.log(`  - ${nDrafts} docs set to 'draft: true'.`);
   console.log(`  - ${nNotDrafts} docs set to 'draft: false'.`);
+  if (nDrafts === 0) {
+     console.log(`  To dynamically publish documents based on date, set the 'draft-after' date in ${ymlPath}.`);
+  }
 
   //return config;
 }


### PR DESCRIPTION
This suggests adding a log message that, if there are no draft documents, that one can use `draft-after` to schedule documents. The use case is if someone has cloned their site from elsewhere and is not aware that the scheduled-docs functionality is available. For such cases, it also clarifies to some degree why they are seeing all the logging messages about the scheduled-docs functionality.

@andrewpbray no worries if you don't like this. Just a suggestion that seemed like it would be useful in the department context.